### PR TITLE
Add `JDP Science Common Utilities` to the Requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ GPreview VS Code is a tool that let's you preview LabVIEW code inside Visual Stu
 - LabVIEW 2019 or later
     - LabVIEW Command Line Interface
     - VI server enabled
+    - [JDP Science Common Utilities](https://www.vipm.io/package/jdp_science_lib_common_utilities/) installed
 
 ## Extension Settings
 


### PR DESCRIPTION
Hi! First, thank you for this great project — I just discovered it today and I think it’s really awesome.

When I installed the extension and tried to open .vi files in VS Code, I consistently received an error. To investigate, I double-clicked CLI.vi in the Explorer, and LabVIEW reported that **JDP Science Common Utilities** was missing. After installing it via VIPM, the .vi files opened correctly in VS Code.

To help other users avoid the same issue, I added JDP Science Common Utilities to the Requirements section.

Thanks for your work, and I hope this PR is helpful!